### PR TITLE
 Added changing text on generate README profile button also make the …

### DIFF
--- a/src/hooks/GitHubProfileGenerator.jsx
+++ b/src/hooks/GitHubProfileGenerator.jsx
@@ -27,6 +27,7 @@ function GitHubProfileGenerator() {
   const [copied, setCopied] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [viewMode, setViewMode] = useState('markdown');
+  const [buttonText,setButtonText] = useState('Generate Profile README')
 
   const handleChange = (e) => {
     setProfileInfo({ ...profileInfo, [e.target.name]: e.target.value });
@@ -130,7 +131,7 @@ ${
   Please fill in the template with the provided information. Do not add any additional sections. Stick strictly to the provided template structure.`;
 
   const result = await model.generateContent(prompt);
-  const response = await result.response;
+  const response = result.response;
   setGeneratedProfile(response.text());
   setIsEditing(false);
 } catch (error) {
@@ -179,12 +180,15 @@ return (
     onClick={generateProfile}
     className="w-full bg-purple-600 text-white py-2 px-4 rounded-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-opacity-50 transition duration-300"
   >
-    Generate Profile README
+    {buttonText}
   </button>
   {isLoading && (
-    <p className="text-purple-400 mt-4">Generating profile README...</p>
+    setButtonText('Generating Profile README...')
   )}
   {error && <p className="text-red-400 mt-4">{error}</p>}
+  {generatedProfile && (
+    setButtonText('Generate Profile README')
+  )}
   {generatedProfile && (
     <div className="mt-8 relative">
       <div className="flex justify-between items-center mb-4">


### PR DESCRIPTION
In this PR, I added the changing text to the Generate Profile README button, so when you click it while generating, it will automatically change to generating and then, after the competition, back to the original.

I also removed unnecessary lines of code that had no effect.
And most importantly, I wrote small and efficient code to change different texts by using the useState hook.



Removed unnecessary code.
![Screenshot from 2024-10-19 17-06-00](https://github.com/user-attachments/assets/68959c76-f66b-4876-b825-97c79b7f6e76)



Handling of button text change.
![Screenshot from 2024-10-19 17-05-45](https://github.com/user-attachments/assets/04ce10f0-26c7-42ea-9e90-bc3fcb15b51b)

Making use of  small code for doing same task.
![Screenshot from 2024-10-19 17-05-20](https://github.com/user-attachments/assets/02b5e560-33dc-45bd-b586-8b804306fb0f)
